### PR TITLE
Makes admin URL prefix configurable

### DIFF
--- a/helpers/helpers.php
+++ b/helpers/helpers.php
@@ -106,7 +106,11 @@ if (! function_exists('admin_url')) {
      */
     function admin_url(?string $uri = null): string
     {
-        return rtrim('/admin-cp/' . ltrim($uri, '/'), '/');
+        return rtrim(
+            '/' . config('core.admin_prefix') . '/'
+            . ltrim($uri, '/'),
+            '/'
+        );
     }
 }
 

--- a/src/resources/views/layouts/admin.blade.php
+++ b/src/resources/views/layouts/admin.blade.php
@@ -45,6 +45,12 @@
                         $breadcrumbs = \Juzaweb\Core\Facades\Breadcrumb::getItems();
                         @endphp
                         <ol class="breadcrumb float-sm-right">
+                            @if($breadcrumbs)
+                            <li class="breadcrumb-item">
+                                <a href="{{ admin_url() }}">{{ __('Dashboard') }}</a>
+                            </li>
+                            @endif
+
                             @foreach($breadcrumbs as $breadcrumb)
                                 @if($breadcrumb['url'])
                                     <li class="breadcrumb-item">


### PR DESCRIPTION
Allows customization of the admin URL prefix via configuration.

This change enhances flexibility by allowing users to define their preferred admin URL prefix instead of being limited to a hardcoded value.

Also, this change adds a default breadcrumb to the admin dashboard link.